### PR TITLE
Stop ESLint errors from blocking compilation

### DIFF
--- a/MeetingTimer/ClientApp/.env
+++ b/MeetingTimer/ClientApp/.env
@@ -1,1 +1,2 @@
 BROWSER=none
+ESLINT_NO_DEV_ERRORS=true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Stop ESLint errors from blocking compilation

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is a [known bug](https://github.com/facebook/create-react-app/issues/9887) where ESLint errors will prevent React compiling. This is really annoying when developing, as even an unused import will result in an error (see image below). `react-scripts 4.0.3` has fixed this but requires setting the `ESLINT_NO_DEV_ERRORS` environment variable. 

## Screenshots (if appropriate):

Before change (error showing in browser):
![image](https://user-images.githubusercontent.com/47089130/116564275-b95c7000-a8fc-11eb-9027-5cbe94564cd3.png)

After change (warning in console only): 
![image](https://user-images.githubusercontent.com/47089130/116564502-f1fc4980-a8fc-11eb-865f-73927a6efceb.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
